### PR TITLE
Restore nightly builds

### DIFF
--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -2,15 +2,18 @@ name: build-apple-darwin
 
 on:
   workflow_dispatch:
+    inputs:
+      noir-ref:
+        description: The noir reference to checkout
+        required: false
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
-  # push:
+  push:
 
 jobs:
   build-apple-darwin:
     runs-on: macos-latest
     strategy:
-      max-parallel: 1
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
 
@@ -23,6 +26,7 @@ jobs:
         with:
           repository: noir-lang/noir
           path: noir
+          ref: ${{ inputs.noir-ref || 'master' }}
 
       - name: Setup for Apple Silicon
         if: matrix.target == 'aarch64-apple-darwin'
@@ -41,24 +45,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Rust toolchain Install
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@1.65.0
         with:
-          toolchain: 1.65.0
-          target: ${{ matrix.target }}
-          default: true
-          override: true
-
-      - name: Patch backend in crates/nargo/Cargo.toml
-        working-directory: noir
-        run: |
-          sed -E -i '' 's/^aztec_backend.+}/aztec_backend = { optional = true, package = "barretenberg_wasm", git = "https:\/\/github.com\/noir-lang\/aztec_backend", rev = "e1f206f6739d3782d3a241298089a0292de33742" }/g' crates/nargo/Cargo.toml
-          echo 🧪 patched backend = ''$(cat crates/nargo/Cargo.toml | grep aztec_backend)''
+          targets: ${{ matrix.target }}
 
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo build --release --target ${{ matrix.target }}
+          cargo build --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
@@ -82,7 +77,7 @@ jobs:
           npm install
           npm test
 
-      - name: Upload binaries to Noir Repo nightly tag
+      - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         with:
@@ -91,4 +86,4 @@ jobs:
           file: ./noir/nargo-${{ matrix.target }}.tar.gz
           asset_name: nargo-${{ matrix.target }}.tar.gz
           overwrite: true
-          tag: nightly
+          tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -2,11 +2,13 @@ name: build-linux
 
 on:
   workflow_dispatch:
+    inputs:
+      noir-ref:
+        description: The noir reference to checkout
+        required: false
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:
-    tags:
-      - "v*"
 
 env:
   CROSS_CONFIG: ${{ github.workspace }}/.github/Cross.toml
@@ -15,37 +17,32 @@ jobs:
   build-linux:
     runs-on: ubuntu-22.04
     strategy:
-      # max-parallel: 1
       fail-fast: false
       matrix:
-        target: [
+        target:
+          [
             x86_64-unknown-linux-gnu,
             x86_64-unknown-linux-musl,
-            i686-unknown-linux-gnu,
-            i686-unknown-linux-musl,
             aarch64-unknown-linux-gnu,
             aarch64-unknown-linux-musl,
-            # arm-unknown-linux-gnueabihf,
-            # arm-unknown-linux-musleabihf,
             riscv64gc-unknown-linux-gnu,
           ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Checkout Noir repo
         uses: actions/checkout@v3
         with:
           repository: noir-lang/noir
           path: noir
+          ref: ${{ inputs.noir-ref || 'master' }}
 
-      - name: Patch backend in crates/nargo/Cargo.toml
+      - name: Patch openssl for cross-compile
         working-directory: noir
         run: |
           sed -i -E 's/\[dependencies\]/\[dependencies\]\nopenssl = { version = "0.10", features = ["vendored"] }/g' ./crates/nargo/Cargo.toml
-          sed -i -E 's/^aztec_backend.+}/aztec_backend = { optional = true, package = "barretenberg_wasm", git = "https:\/\/github.com\/noir-lang\/aztec_backend", rev = "e1f206f6739d3782d3a241298089a0292de33742" }/g' ./crates/nargo/Cargo.toml
-          echo 🧪 patched backend = ''$(cat crates/nargo/Cargo.toml | grep aztec_backend)''
 
       - uses: actions/cache@v3
         with:
@@ -57,18 +54,16 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@1.65.0
         with:
-          toolchain: 1.65.0
-          target: ${{ matrix.target }}
-          default: true
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Build Nargo
         working-directory: noir
         run: |
           cargo install cross --force --git https://github.com/cross-rs/cross
-          cross build --release --target=${{ matrix.target }}
+          cross build --package nargo --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
@@ -87,12 +82,12 @@ jobs:
           retention-days: 3
 
       - name: Test built artifact
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        if: startsWith(matrix.target, 'x86_64-unknown-linux')
         run: |
           npm install
           npm test
 
-      - name: Upload binaries to Noir Repo nightly tag
+      - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         with:
@@ -101,4 +96,4 @@ jobs:
           file: ./noir/nargo-${{ matrix.target }}.tar.gz
           asset_name: nargo-${{ matrix.target }}.tar.gz
           overwrite: true
-          tag: nightly
+          tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -4,15 +4,18 @@ name: build-x86_64-pc-windows-wasm
 
 on:
   workflow_dispatch:
+    inputs:
+      noir-ref:
+        description: The noir reference to checkout
+        required: false
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
-  # push:
+  push:
 
 jobs:
   build-x86_64-pc-windows-msvc:
     runs-on: windows-2022
     strategy:
-      max-parallel: 1
       matrix:
         target: [x86_64-pc-windows-msvc]
 
@@ -25,6 +28,7 @@ jobs:
         with:
           repository: noir-lang/noir
           path: noir
+          ref: ${{ inputs.noir-ref || 'master' }}
 
       - uses: actions/cache@v3
         with:
@@ -36,23 +40,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Rust toolchain Install
-        uses: actions-rs/toolchain@v1
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@1.65.0
         with:
-          toolchain: 1.65.0
-          target: ${{ matrix.target }}
-          default: true
-          override: true
-
-      - name: Patch backend in crates/nargo/Cargo.toml
-        working-directory: noir
-        run: |
-          (Get-Content crates/nargo/Cargo.toml) -replace 'aztec_backend = {(.+)}','aztec_backend = { optional = true, package = "barretenberg_wasm", git = "https://github.com/noir-lang/aztec_backend", rev = "e1f206f6739d3782d3a241298089a0292de33742" }' | Out-File -encoding ASCII crates/nargo/Cargo.toml
+          targets: ${{ matrix.target }}
 
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo build --release --target ${{ matrix.target }}
+          cargo build --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
@@ -78,7 +74,7 @@ jobs:
           npm install
           npm test
 
-      - name: Upload binaries to Noir Repo nightly tag
+      - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         with:
@@ -87,4 +83,4 @@ jobs:
           file: ./noir/nargo-${{ matrix.target }}.zip
           asset_name: nargo-${{ matrix.target }}.zip
           overwrite: true
-          tag: nightly
+          tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)


### PR DESCRIPTION
This PR does a bunch of things and ensures all targets can be built from Noir master:

* Utilize the aztec_wasm_backend feature to build binaries
* Remove patches to build wasm backend
* Update the cross-compile matrix
* Cleanup the workflows
* Update the rust toolchain action
* Also test musl linux binary
* Introduce noir-ref input for building branches or tags