### PR TITLE
feat: Build with rustls and remove openssl hack

### DIFF
--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -25,7 +25,6 @@ jobs:
             x86_64-unknown-linux-musl,
             aarch64-unknown-linux-gnu,
             aarch64-unknown-linux-musl,
-            riscv64gc-unknown-linux-gnu,
           ]
 
     steps:

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -39,11 +39,6 @@ jobs:
           path: noir
           ref: ${{ inputs.noir-ref || 'master' }}
 
-      - name: Patch openssl for cross-compile
-        working-directory: noir
-        run: |
-          sed -i -E 's/\[dependencies\]/\[dependencies\]\nopenssl = { version = "0.10", features = ["vendored"] }/g' ./crates/nargo/Cargo.toml
-
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
This builds a Noir branch where I've replaced `openssl` with `rustls`, see https://github.com/noir-lang/aztec_backend/pull/46 and https://github.com/noir-lang/noir/pull/691 for more details. 

This allows us to remove the openssl hack needed to cross-compile. However, we lose RISC-V support because `rustls` doesn't support it yet.