### PR TITLE
feat(ci): Allow workflow to be called from another repository

### DIFF
--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -1,11 +1,21 @@
 name: build-apple-darwin
 
 on:
+  workflow_call:
+    inputs:
+      noir-ref:
+        description: The noir reference to checkout
+        required: true # Required so it can only be run on a tag as a workflow_call
+        type: string
+    secrets:
+      NOIR_REPO_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       noir-ref:
         description: The noir reference to checkout
         required: false
+        type: string
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -1,11 +1,21 @@
 name: build-linux
 
 on:
+  workflow_call:
+    inputs:
+      noir-ref:
+        description: The noir reference to checkout
+        required: true # Required so it can only be run on a tag as a workflow_call
+        type: string
+    secrets:
+      NOIR_REPO_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       noir-ref:
         description: The noir reference to checkout
         required: false
+        type: string
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -3,11 +3,21 @@ name: build-x86_64-pc-windows-wasm
 # <arch>-<vendor>-<os>-<env>
 
 on:
+  workflow_call:
+    inputs:
+      noir-ref:
+        description: The noir reference to checkout
+        required: true # Required so it can only be run on a tag as a workflow_call
+        type: string
+    secrets:
+      NOIR_REPO_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       noir-ref:
         description: The noir reference to checkout
         required: false
+        type: string
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:


### PR DESCRIPTION
This adds the `workflow_call` event to trigger these workflows. This will allow us to call them directly from the release process in the main noir repo.