### PR TITLE
chore: Prevent creating a release which includes uncommitted changes

### DIFF
--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -67,7 +67,7 @@ jobs:
       # Nargo appends "modified" to its build commit if the commit had uncommitted changes.
       # We want to avoid this making it into a stable release so reject if this string is present. 
       - name: Check for dirty build
-        working-directory: ./dist
+        working-directory: ./noir/dist
         run: |
           if grep -q "modified" <<< $(./nargo --version); then
               echo "::error::Building Nargo from a dirty commit" && exit 1

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -64,6 +64,15 @@ jobs:
           cp -r noir_stdlib/* ./dist/noir-lang/std/
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
+      # Nargo appends "modified" to its build commit if the commit had uncommitted changes.
+      # We want to avoid this making it into a stable release so reject if this string is present. 
+      - name: Check for dirty build
+        working-directory: ./dist
+        run: |
+          if grep -q "modified" <<< $(./nargo --version); then
+              echo "::error::Building Nargo from a dirty commit" && exit 1
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -71,7 +71,7 @@ jobs:
       # Nargo appends "modified" to its build commit if the commit had uncommitted changes.
       # We want to avoid this making it into a stable release so reject if this string is present. 
       - name: Check for dirty build
-        working-directory: ./dist
+        working-directory: ./noir/dist
         run: |
           if grep -q "modified" <<< $(./nargo --version); then
               echo "::error::Building Nargo from a dirty commit" && exit 1

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -68,6 +68,15 @@ jobs:
           cp -r noir_stdlib/* ./dist/noir-lang/std/
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
+      # Nargo appends "modified" to its build commit if the commit had uncommitted changes.
+      # We want to avoid this making it into a stable release so reject if this string is present. 
+      - name: Check for dirty build
+        working-directory: ./dist
+        run: |
+          if grep -q "modified" <<< $(./nargo --version); then
+              echo "::error::Building Nargo from a dirty commit" && exit 1
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -64,7 +64,7 @@ jobs:
       # Nargo appends "modified" to its build commit if the commit had uncommitted changes.
       # We want to avoid this making it into a stable release so reject if this string is present. 
       - name: Check for dirty build
-        working-directory: ./dist
+        working-directory: ./noir/dist
         run: |
           if grep -q "modified" <<< $(./nargo --version); then
               echo "::error::Building Nargo from a dirty commit" && exit 1

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -61,6 +61,15 @@ jobs:
           cp -R noir_stdlib/* ./dist/noir-lang/std/
           7z a -tzip nargo-${{ matrix.target }}.zip ./dist/*
 
+      # Nargo appends "modified" to its build commit if the commit had uncommitted changes.
+      # We want to avoid this making it into a stable release so reject if this string is present. 
+      - name: Check for dirty build
+        working-directory: ./dist
+        run: |
+          if grep -q "modified" <<< $(./nargo --version); then
+              echo "::error::Building Nargo from a dirty commit" && exit 1
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -65,6 +65,7 @@ jobs:
       # We want to avoid this making it into a stable release so reject if this string is present. 
       - name: Check for dirty build
         working-directory: ./noir/dist
+        shell: bash
         run: |
           if grep -q "modified" <<< $(./nargo --version); then
               echo "::error::Building Nargo from a dirty commit" && exit 1


### PR DESCRIPTION
I noticed that the `0.1.0` version of nargo doesn't correspond to the commit from which it was built (running `nargo --version` returns a git commit suffixed with `modified`). This PR adds a quick check so that if the output of `nargo --version` includes this suffix then the release is halted.

I think that the issue with 0.1.0 is due to this release being made prior to `build-nargo` existing and so this check shouldn't trigger here however I think we should explicitly check to ensure that the builds we publish correspond to the commits we're saying they're from.