### PR TITLE
chore: add node modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "build-noir",
+  "name": "build-nargo",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Running the tests locally results in git attempting to track the installed deps. This PR adds a `.gitignore` file to avoid this. 