### PR TITLE
feat: add test to check that nargo has been built from a clean commit

### DIFF
--- a/test/6_array.test.js
+++ b/test/6_array.test.js
@@ -32,11 +32,6 @@ test("promise resolved", async () => {
   promiseResolved = true;
 });
 
-test("prints version", async () => {
-  const processOutput = (await $`${nargoBin} --version`).toString();
-  assert.match(processOutput, /nargo\s\d{1,2}.\d{1,2}/);
-});
-
 test("nargo builds noir/test/test_data/6_array sucessfully", async () => {
   await within(async () => {
     cd("./noir/crates/nargo/tests/test_data/6_array");

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -39,7 +39,7 @@ test("prints version", async () => {
 
 test("reports a clean commit", async () => {
   const processOutput = (await $`${nargoBin} --version`).toString();
-  assert.not.match(processOutput, /modified/)
+  assert.not.match(processOutput, /is dirty: true/)
 });
 
 test.run();

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -1,0 +1,45 @@
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+import { cd } from "zx";
+import "zx/globals";
+
+const test = suite("nargo");
+
+const nargoBinPath = path.join(process.cwd(), "noir/dist/");
+const nargoBin = path.join(nargoBinPath, "nargo");
+
+if (process.platform == "win32") {
+  $.shell = "powershell";
+}
+
+$.quote = (arg) => {
+  return arg;
+};
+
+$.verbose = true;
+
+// Helps detect unresolved ProcessPromise.
+let promiseResolved = false;
+process.on("exit", () => {
+  if (!promiseResolved) {
+    console.error("Error: ProcessPromise never resolved.");
+    process.exitCode = 1;
+  }
+});
+
+test("promise resolved", async () => {
+  await $`echo PromiseHelper`;
+  promiseResolved = true;
+});
+
+test("prints version", async () => {
+  const processOutput = (await $`${nargoBin} --version`).toString();
+  assert.match(processOutput, /nargo\s\d{1,2}.\d{1,2}/);
+});
+
+test("reports a clean commit", async () => {
+  const processOutput = (await $`${nargoBin} --version`).toString();
+  assert.not.match(processOutput, /modified/)
+});
+
+test.run();


### PR DESCRIPTION
I've moved the check from #6 into a uvu test so that the check being added in that PR is handled as part of the testing step.

The tests related to `nargo`'s version have been split off into a separate test file from the tests on `6_array`.