### PR TITLE
chore: remove bundling of stdlib crate

### DIFF
--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -60,8 +60,6 @@ jobs:
         run: |
           mkdir dist
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
-          mkdir -p ./dist/noir-lang/std
-          cp -r noir_stdlib/* ./dist/noir-lang/std/
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -64,8 +64,6 @@ jobs:
         run: |
           mkdir dist
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
-          mkdir -p ./dist/noir-lang/std
-          cp -r noir_stdlib/* ./dist/noir-lang/std/
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -57,8 +57,6 @@ jobs:
           ls target
           ls target/release
           cp ./target/${{ matrix.target }}/release/nargo.exe ./dist/nargo.exe
-          mkdir -p ./dist/noir-lang/std
-          cp -R noir_stdlib/* ./dist/noir-lang/std/
           7z a -tzip nargo-${{ matrix.target }}.zip ./dist/*
 
       - name: Upload artifact


### PR DESCRIPTION
Including the stdlib in the releases is unnecessary after https://github.com/noir-lang/noir/pull/973