### PR TITLE
chore: raise an issue when nightly build fails

### DIFF
--- a/.github/NIGHTLY_BUILD_FAILURE.md
+++ b/.github/NIGHTLY_BUILD_FAILURE.md
@@ -1,0 +1,11 @@
+---
+title: "nightly build failed"
+assignees: kobyhallx, phated, tomafrench
+labels: bug
+---
+
+Something broke our nightly builds.
+
+Check the [build]({{env.WORKFLOW_URL}}) workflow for details.
+
+This issue was raised by the workflow `{{env.WORKFLOW_NAME}}`

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -89,7 +89,7 @@ jobs:
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
 
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() }}
+        if: ${{ failure() }} && github.event_name == 'schedule'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -87,7 +87,7 @@ jobs:
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
 
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() }} && github.event_name == 'schedule'
+        if: ${{ failure() && github.event_name == 'schedule' }} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -86,7 +86,9 @@ jobs:
           overwrite: true
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
 
-      - uses: JasonEtco/create-an-issue@v2
+      # If we're performing a nightly build and it fails acceptance tests then raise an issue.
+      - name: Alert on nightly build failure
+        uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() && github.event_name == 'schedule' }} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -87,3 +87,13 @@ jobs:
           asset_name: nargo-${{ matrix.target }}.tar.gz
           overwrite: true
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
+
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/NIGHTLY_BUILD_FAILURE.md

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -90,7 +90,9 @@ jobs:
           overwrite: true
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
       
-      - uses: JasonEtco/create-an-issue@v2
+      # If we're performing a nightly build and it fails acceptance tests then raise an issue.
+      - name: Alert on nightly build failure
+        uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -93,7 +93,7 @@ jobs:
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
       
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() }}
+        if: ${{ failure() }} && github.event_name == 'schedule'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -91,7 +91,7 @@ jobs:
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
       
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() }} && github.event_name == 'schedule'
+        if: ${{ failure() && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -91,3 +91,13 @@ jobs:
           asset_name: nargo-${{ matrix.target }}.tar.gz
           overwrite: true
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
+      
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/NIGHTLY_BUILD_FAILURE.md

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -84,3 +84,13 @@ jobs:
           asset_name: nargo-${{ matrix.target }}.zip
           overwrite: true
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
+      
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/NIGHTLY_BUILD_FAILURE.md

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -83,7 +83,9 @@ jobs:
           overwrite: true
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
       
-      - uses: JasonEtco/create-an-issue@v2
+      # If we're performing a nightly build and it fails acceptance tests then raise an issue.
+      - name: Alert on nightly build failure
+        uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -86,7 +86,7 @@ jobs:
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
       
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() }}
+        if: ${{ failure() }} && github.event_name == 'schedule'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -84,7 +84,7 @@ jobs:
           tag: ${{ inputs.noir-ref || 'nightly' }} # This will fail if noir-ref is not a tag (e.g. testing a branch)
       
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ failure() }} && github.event_name == 'schedule'
+        if: ${{ failure() && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_NAME: ${{ github.workflow }}


### PR DESCRIPTION
We've had failing nightly builds for a [couple of weeks now](https://github.com/noir-lang/noir/pull/892) but I didn't notice it until today due to us not having monitoring set up.

As a simple version of this, the build workflows now open an issue when they fail to ping us. I've added a couple of people to be assigned based on who tends to tinker with CI the most, if you'd rather be removed from this then let me know.