### PR TITLE
chore: factor out duplicated test setup

### DIFF
--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo install --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cargo install --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: noir
         run: |
           mkdir dist
-          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
+          cp ./noir/target/${{ matrix.target }}/release/nargo ./dist/nargo
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -53,13 +53,13 @@ jobs:
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo install --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cargo build --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
         run: |
           mkdir dist
-          cp ~/.cargo/bin/nargo ./dist/nargo
+          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact
@@ -72,6 +72,7 @@ jobs:
       - name: Test built artifact
         if: matrix.target == 'x86_64-apple-darwin'
         run: |
+          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
           npm install
           npm test
 

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -53,13 +53,13 @@ jobs:
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo build --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cargo install --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
         run: |
           mkdir dist
-          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
+          cp ~/.cargo/bin/nargo ./dist/nargo
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact
@@ -74,8 +74,6 @@ jobs:
         run: |
           npm install
           npm test
-        env:
-          NARGO_PATH: "./noir/dist/nargo"
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -60,7 +60,6 @@ jobs:
         run: |
           mkdir dist
           cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
-
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -74,6 +74,8 @@ jobs:
         run: |
           npm install
           npm test
+        env:
+          NARGO_PATH: "./noir/dist/nargo"
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -72,7 +72,8 @@ jobs:
       - name: Test built artifact
         if: matrix.target == 'x86_64-apple-darwin'
         run: |
-          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+          cp ./noir/target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+
           npm install
           npm test
 

--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -59,7 +59,8 @@ jobs:
         working-directory: noir
         run: |
           mkdir dist
-          cp ./noir/target/${{ matrix.target }}/release/nargo ./dist/nargo
+          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
+
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: noir
         run: |
           cargo install cross --force --git https://github.com/cross-rs/cross
-          cross install --package nargo --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cross install --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -78,6 +78,8 @@ jobs:
         run: |
           npm install
           npm test
+        env:
+          NARGO_PATH: "./noir/dist/nargo"
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Test built artifact
         if: startsWith(matrix.target, 'x86_64-unknown-linux')
         run: |
-          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+          cp ./noir/target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
           npm install
           npm test
 

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -57,13 +57,13 @@ jobs:
         working-directory: noir
         run: |
           cargo install cross --force --git https://github.com/cross-rs/cross
-          cross build --package nargo --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cross install --package nargo --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
         run: |
           mkdir dist
-          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
+          cp ~/.cargo/bin/nargo ./dist/nargo
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact
@@ -78,8 +78,6 @@ jobs:
         run: |
           npm install
           npm test
-        env:
-          NARGO_PATH: "./noir/dist/nargo"
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -57,13 +57,13 @@ jobs:
         working-directory: noir
         run: |
           cargo install cross --force --git https://github.com/cross-rs/cross
-          cross install --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cross build --package nargo --release --target=${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
         run: |
           mkdir dist
-          cp ~/.cargo/bin/nargo ./dist/nargo
+          cp ./target/${{ matrix.target }}/release/nargo ./dist/nargo
           7z a -ttar -so -an ./dist/* | 7z a -si ./nargo-${{ matrix.target }}.tar.gz
 
       - name: Upload artifact
@@ -76,6 +76,7 @@ jobs:
       - name: Test built artifact
         if: startsWith(matrix.target, 'x86_64-unknown-linux')
         run: |
+          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
           npm install
           npm test
 

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -71,6 +71,8 @@ jobs:
         run: |
           npm install
           npm test
+        env:
+          NARGO_PATH: "./noir/dist/nargo"
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -48,15 +48,13 @@ jobs:
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo build --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cargo install --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
         run: |
           mkdir dist
-          ls target
-          ls target/release
-          cp ./target/${{ matrix.target }}/release/nargo.exe ./dist/nargo.exe
+          cp ~/.cargo/bin/nargo.exe ./dist/nargo.exe
           7z a -tzip nargo-${{ matrix.target }}.zip ./dist/*
 
       - name: Upload artifact
@@ -71,8 +69,6 @@ jobs:
         run: |
           npm install
           npm test
-        env:
-          NARGO_PATH: "./noir/dist/nargo"
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo install --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cargo build --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir
         run: |
           mkdir dist
-          cp ~/.cargo/bin/nargo.exe ./dist/nargo.exe
+          cp ./target/${{ matrix.target }}/release/nargo.exe ./dist/nargo.exe
           7z a -tzip nargo-${{ matrix.target }}.zip ./dist/*
 
       - name: Upload artifact
@@ -67,6 +67,7 @@ jobs:
       - name: Test built artifact
         shell: powershell
         run: |
+          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
           npm install
           npm test
 

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Test built artifact
         shell: powershell
         run: |
-          cp ./noir/target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+          cp ./noir/target/${{ matrix.target }}/release/nargo.exe ~/.cargo/bin/
+
           npm install
           npm test
 

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build environment and Compile
         working-directory: noir
         run: |
-          cargo install --package nargo --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
+          cargo install --release --target ${{ matrix.target }} --no-default-features --features plonk_bn254_wasm
 
       - name: Package artifacts
         working-directory: noir

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Test built artifact
         shell: powershell
         run: |
-          cp ./target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
+          cp ./noir/target/${{ matrix.target }}/release/nargo ~/.cargo/bin/
           npm install
           npm test
 

--- a/test/6_array.test.js
+++ b/test/6_array.test.js
@@ -1,5 +1,4 @@
 import { suite } from "uvu";
-import * as assert from "uvu/assert";
 import { cd } from "zx";
 import "zx/globals";
 

--- a/test/6_array.test.js
+++ b/test/6_array.test.js
@@ -5,16 +5,6 @@ import "./utils/zx.js";
 
 const test = suite("nargo");
 
-if (process.platform == "win32") {
-  $.shell = "powershell";
-}
-
-$.quote = (arg) => {
-  return arg;
-};
-
-$.verbose = true;
-
 // Helps detect unresolved ProcessPromise.
 let promiseResolved = false;
 process.on("exit", () => {

--- a/test/6_array.test.js
+++ b/test/6_array.test.js
@@ -1,11 +1,9 @@
 import { suite } from "uvu";
 import { cd } from "zx";
-import "zx/globals";
+import { NARGO_BIN } from "./utils/nargo.js";
+import "./utils/zx.js";
 
 const test = suite("nargo");
-
-const nargoBinPath = path.join(process.cwd(), "noir/dist/");
-const nargoBin = path.join(nargoBinPath, "nargo");
 
 if (process.platform == "win32") {
   $.shell = "powershell";
@@ -34,7 +32,7 @@ test("promise resolved", async () => {
 test("nargo builds noir/test/test_data/6_array sucessfully", async () => {
   await within(async () => {
     cd("./noir/crates/nargo/tests/test_data/6_array");
-    const command = `${nargoBin} check`;
+    const command = `${NARGO_BIN} check`;
 
     await $`${command}`.nothrow();
   });
@@ -43,7 +41,7 @@ test("nargo builds noir/test/test_data/6_array sucessfully", async () => {
 test("nargo creates proof noir/test/test_data/6_array sucessfully", async () => {
   await within(async () => {
     cd("./noir/crates/nargo/tests/test_data/6_array");
-    const command = `${nargoBin} prove 6_array`;
+    const command = `${NARGO_BIN} prove 6_array`;
 
     await $`${command}`.nothrow();
   });
@@ -52,7 +50,7 @@ test("nargo creates proof noir/test/test_data/6_array sucessfully", async () => 
 test("nargo verifies proof noir/test/test_data/6_array sucessfully", async () => {
   await within(async () => {
     cd("./noir/crates/nargo/tests/test_data/6_array");
-    const command = `${nargoBin} verify 6_array`;
+    const command = `${NARGO_BIN} verify 6_array`;
 
     await $`${command}`.nothrow();
   });

--- a/test/utils/nargo.js
+++ b/test/utils/nargo.js
@@ -1,3 +1,3 @@
 import { parse } from "node:path";
 
-export const NARGO_BIN = parse(process.env.NARGO_PATH) ?? "nargo";
+export const NARGO_BIN = process.env.NARGO_PATH ? parse(process.env.NARGO_PATH) : "nargo";

--- a/test/utils/nargo.js
+++ b/test/utils/nargo.js
@@ -1,3 +1,3 @@
-import { parse } from "node:path";
+import { default as path } from "node:path";
 
-export const NARGO_BIN = process.env.NARGO_PATH ? parse(process.env.NARGO_PATH) : "nargo";
+export const NARGO_BIN = process.env.NARGO_PATH ? path.resolve(process.env.NARGO_PATH) : "nargo";

--- a/test/utils/nargo.js
+++ b/test/utils/nargo.js
@@ -1,3 +1,3 @@
 import { default as path } from "node:path";
 
-export const NARGO_BIN = process.env.NARGO_PATH ? path.resolve(process.env.NARGO_PATH) : "nargo";
+export const NARGO_BIN = process.env.NARGO_BIN ? path.resolve(process.env.NARGO_BIN) : "nargo";

--- a/test/utils/nargo.js
+++ b/test/utils/nargo.js
@@ -1,0 +1,1 @@
+export const NARGO_BIN = process.env.NARGO_PATH ?? "nargo";

--- a/test/utils/nargo.js
+++ b/test/utils/nargo.js
@@ -1,1 +1,3 @@
-export const NARGO_BIN = path.parse(process.env.NARGO_PATH) ?? "nargo";
+import { parse } from "node:path";
+
+export const NARGO_BIN = parse(process.env.NARGO_PATH) ?? "nargo";

--- a/test/utils/nargo.js
+++ b/test/utils/nargo.js
@@ -1,1 +1,1 @@
-export const NARGO_BIN = process.env.NARGO_PATH ?? "nargo";
+export const NARGO_BIN = path.parse(process.env.NARGO_PATH) ?? "nargo";

--- a/test/utils/zx.js
+++ b/test/utils/zx.js
@@ -1,0 +1,11 @@
+import "zx/globals";
+
+// We perform any common setup for zx here to avoid repetition across test files.
+
+if (process.platform == "win32") {
+    $.shell = "powershell";
+}
+  
+$.quote = (arg) => arg;
+
+$.verbose = true;

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -1,6 +1,5 @@
 import { suite } from "uvu";
 import * as assert from "uvu/assert";
-import { cd } from "zx";
 import "zx/globals";
 
 const test = suite("nargo");

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -5,16 +5,6 @@ import "./utils/zx.js";
 
 const test = suite("nargo");
 
-if (process.platform == "win32") {
-  $.shell = "powershell";
-}
-
-$.quote = (arg) => {
-  return arg;
-};
-
-$.verbose = true;
-
 // Helps detect unresolved ProcessPromise.
 let promiseResolved = false;
 process.on("exit", () => {

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -1,11 +1,9 @@
 import { suite } from "uvu";
 import * as assert from "uvu/assert";
-import "zx/globals";
+import { NARGO_BIN } from "./utils/nargo.js";
+import "./utils/zx.js";
 
 const test = suite("nargo");
-
-const nargoBinPath = path.join(process.cwd(), "noir/dist/");
-const nargoBin = path.join(nargoBinPath, "nargo");
 
 if (process.platform == "win32") {
   $.shell = "powershell";
@@ -32,12 +30,12 @@ test("promise resolved", async () => {
 });
 
 test("prints version", async () => {
-  const processOutput = (await $`${nargoBin} --version`).toString();
+  const processOutput = (await $`${NARGO_BIN} --version`).toString();
   assert.match(processOutput, /nargo\s\d{1,2}.\d{1,2}/);
 });
 
 test("reports a clean commit", async () => {
-  const processOutput = (await $`${nargoBin} --version`).toString();
+  const processOutput = (await $`${NARGO_BIN} --version`).toString();
   assert.not.match(processOutput, /is dirty: true/)
 });
 


### PR DESCRIPTION
I'm looking to add a few more test cases here. First we need to factor out some duplicated code from the test files.

Ideally we'd be able to run the test suite against our locally installed version of nargo instead of being coupled to the CI runner's environment, so I've added an environment variable to pass in the location of the `nargo` binary otherwise it just looks in the PATH.