### PR TITLE
feat: add "publish" input to workflows

### DIFF
--- a/.github/workflows/publish-apple-darwin-wasm.yml
+++ b/.github/workflows/publish-apple-darwin-wasm.yml
@@ -6,6 +6,10 @@ on:
       noir-ref:
         description: The noir reference to checkout
         required: false
+      publish:
+        type: boolean
+        description: Whether to publish the build artifacts
+        default: false
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:
@@ -79,7 +83,7 @@ jobs:
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: ${{ inputs.publish || github.event_name == 'schedule' }} # A scheduled run implies a nightly release
         with:
           repo_name: noir-lang/noir
           repo_token: ${{ secrets.NOIR_REPO_TOKEN }}

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -6,6 +6,10 @@ on:
       noir-ref:
         description: The noir reference to checkout
         required: false
+      publish:
+        type: boolean
+        description: Whether to publish the build artifacts
+        default: false
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:
@@ -82,7 +86,7 @@ jobs:
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: ${{ inputs.publish || github.event_name == 'schedule' }} # A scheduled run implies a nightly release
         with:
           repo_name: noir-lang/noir
           repo_token: ${{ secrets.NOIR_REPO_TOKEN }}

--- a/.github/workflows/publish-x86_64-pc-windows-wasm.yml
+++ b/.github/workflows/publish-x86_64-pc-windows-wasm.yml
@@ -8,6 +8,10 @@ on:
       noir-ref:
         description: The noir reference to checkout
         required: false
+      publish:
+        type: boolean
+        description: Whether to publish the build artifacts
+        default: false
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
   push:
@@ -74,7 +78,7 @@ jobs:
 
       - name: Upload binaries to Noir Repo
         uses: svenstaro/upload-release-action@v2
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: ${{ inputs.publish || github.event_name == 'schedule' }} # A scheduled run implies a nightly release
         with:
           repo_name: noir-lang/noir
           repo_token: ${{ secrets.NOIR_REPO_TOKEN }}


### PR DESCRIPTION
We don't currently block making new releases if they will fail to be built and published. We should then run the publish command in the release-please PRs to check that they will succeed before merging. Otherwise we can make a release on https://github.com/noir-lang/noir, have it fail to create a binary and we get zero feedback on this until we check manually.

To accommodate this I have added a `publish` input to the workflows, if the `publish` flag is not set then we shall build and test the release but not publish it. We can then add this as a condition to merge the `release-please--branches--master--components--noir` branch in the main repo.