### PR TITLE
fix: checkout repo before trying to raise issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ jobs:
   build-barretenberg:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Checkout Noir repo
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fixes an issue with #27 due to the build step not checking out this repository so it can't find the issue template